### PR TITLE
fix: include comment header when getting existing comment ID

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -13,7 +13,7 @@ const packageLockParser = new PackageLockParser()
 
 const COMMENT_IDENTIFIER = '<!-- npm-lockfile-changes-action comment -->'
 
-const getCommentId = async (octokit, oktokitParams, issueNumber) => {
+const getCommentId = async (octokit, oktokitParams, issueNumber, commentHeader) => {
   const currentComments = await octokit.rest.issues.listComments({
     ...oktokitParams,
     issue_number: issueNumber,
@@ -25,7 +25,7 @@ const getCommentId = async (octokit, oktokitParams, issueNumber) => {
   }
 
   return currentComments.data
-    .filter(({ body }) => body.includes(COMMENT_IDENTIFIER))
+    .filter(({ body }) => body.includes(COMMENT_IDENTIFIER) && body.includes(commentHeader))
     .map(({ id }) => id)[0]
 }
 


### PR DESCRIPTION
This ensures that comments about different lockfiles are distinct - a comment about one lockfile will not be updated with a comment from a lockfile in a different path.